### PR TITLE
Use Path for watchlist output path

### DIFF
--- a/scripts/build_watchlist.py
+++ b/scripts/build_watchlist.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 import json
+from pathlib import Path
+
 
 def main():
-    candidates = ["AAPL","MSFT","GOOG"]
-    with open("data/watchlist.jsonl", "w") as f:
+    candidates = ["AAPL", "MSFT", "GOOG"]
+    output_path = Path(__file__).parent.parent / "data" / "watchlist.jsonl"
+    with output_path.open("w") as f:
         for t in candidates:
             f.write(json.dumps({"ticker": t}) + "\n")
     print("✅ watchlist.jsonl created")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- compute the watchlist output path relative to the project root using `Path(__file__).parent.parent / "data" / "watchlist.jsonl"`
- use the resolved path when writing the JSONL file

## Testing
- `python scripts/build_watchlist.py`
- `python -m py_compile scripts/build_watchlist.py`


------
https://chatgpt.com/codex/tasks/task_e_689507f5ce508321a2af234496f582ca