### PR TITLE
Add benchmark download with fallback for performance chart

### DIFF
--- a/scripts/generate_graph.py
+++ b/scripts/generate_graph.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-import pandas as pd
-import matplotlib.pyplot as plt
 import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import yfinance as yf
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--days", type=int, required=True)
@@ -11,11 +14,42 @@ args = parser.parse_args()
 
 pf = pd.read_csv("data/portfolio_update.csv", parse_dates=["Date"]).set_index("Date")
 eq = pf["Equity"].resample("D").ffill()
-bench = pd.read_csv("data/portfolio_update.csv", parse_dates=["Date"]).set_index("Date")  # placeholder
+
+end = eq.index.max()
+start = end - pd.Timedelta(days=args.days - 1)
+eq = eq[start:]
+
+
+def fetch_benchmark(symbol: str) -> pd.Series:
+    data = yf.download(symbol, start=start, end=end + pd.Timedelta(days=1), progress=False)
+    if data.empty:
+        raise ValueError(f"no data for {symbol}")
+    return data["Adj Close"]
+
+
+bench_symbol = args.bench
+bench = None
+try:
+    bench = fetch_benchmark(bench_symbol)
+except Exception:
+    print(f"⚠️ Failed to download {bench_symbol}, trying fallback {args.fallback}")
+    bench_symbol = args.fallback
+    try:
+        bench = fetch_benchmark(bench_symbol)
+        print(f"⚠️ Falling back to {bench_symbol}")
+    except Exception:
+        print(f"⚠️ Failed to download fallback benchmark {bench_symbol}. Proceeding without benchmark")
+
 fig, ax = plt.subplots()
 ax.plot(eq.index, eq.values, label="Equity")
-ax.set_title(f"Equity last {args.days} days")
+if bench is not None:
+    bench = bench.reindex(eq.index, method="ffill")
+    ax.plot(bench.index, bench.values, label=bench_symbol)
+    ax.set_title(f"Equity vs {bench_symbol} last {args.days} days")
+else:
+    ax.set_title(f"Equity last {args.days} days")
 ax.legend()
 plt.tight_layout()
+Path("charts").mkdir(exist_ok=True)
 plt.savefig("charts/performance.png")
 print("✅ Chart saved to charts/performance.png")


### PR DESCRIPTION
## Summary
- Fetch benchmark prices via `yfinance` with fallback symbol
- Plot portfolio equity against benchmark when available
- Handle missing benchmark data gracefully

## Testing
- `python -m py_compile scripts/generate_graph.py`
- `python scripts/generate_graph.py --days 30 --bench ^RUT --fallback IWM` *(fails to fetch benchmark due to network restrictions but script completes with equity only)*

------
https://chatgpt.com/codex/tasks/task_e_689507f1379c8321ba2a8caa33fb7ed6