### PR TITLE
Unify portfolio schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .venv/
 env/
 data/*.csv
+!data/portfolio_update.csv
 data/*.json
 charts/
 backup/

--- a/data/portfolio_update.csv
+++ b/data/portfolio_update.csv
@@ -1,0 +1,2 @@
+Date,Ticker,Shares,Cost,Stop,Price,Value,PnL,Cash,Equity
+1970-01-01,TOTAL,,,,,,,0,0

--- a/scripts/fix_total_today.py
+++ b/scripts/fix_total_today.py
@@ -9,13 +9,15 @@ pos_val = df["Value"].sum()
 cash = 5000.0 - df["Cost"].sum()
 out = pd.DataFrame([{
     "Date": today.isoformat(),
-    "Ticker":"TOTAL",
-    "Shares":"",
-    "Price":"",
-    "Cost":"",
+    "Ticker": "TOTAL",
+    "Shares": "",
+    "Cost": "",
+    "Stop": "",
+    "Price": "",
     "Value": pos_val,
+    "PnL": "",
     "Cash": cash,
-    "Equity": pos_val + cash
+    "Equity": pos_val + cash,
 }])
 out.to_csv("data/portfolio_update.csv", index=False)
 print(f"✅ TOTAL for {today} set to {pos_val+cash:.2f}")

--- a/scripts/generate_graph.py
+++ b/scripts/generate_graph.py
@@ -10,8 +10,8 @@ parser.add_argument("--fallback", required=True)
 args = parser.parse_args()
 
 pf = pd.read_csv("data/portfolio_update.csv", parse_dates=["Date"]).set_index("Date")
+# equity series (uses unified 'Equity' column)
 eq = pf["Equity"].resample("D").ffill()
-bench = pd.read_csv("data/portfolio_update.csv", parse_dates=["Date"]).set_index("Date")  # placeholder
 fig, ax = plt.subplots()
 ax.plot(eq.index, eq.values, label="Equity")
 ax.set_title(f"Equity last {args.days} days")

--- a/scripts/overlay_stats.py
+++ b/scripts/overlay_stats.py
@@ -13,7 +13,10 @@ trades = pd.read_csv(args.trades) if args.trades else pd.DataFrame()
 base = json.load(open(args.baseline))
 
 # compute stats
-total_equity = (df["Shares"] * df["Price"]).sum()
+if "Equity" in df.columns:
+    total_equity = df["Equity"].sum()
+else:
+    total_equity = (df["Shares"] * df["Price"]).sum()
 buy_count  = len(trades[trades["Shares Bought"]>0])    if "Shares Bought" in trades else 0
 sell_count = len(trades[trades["Shares Sold"]>0])      if "Shares Sold" in trades else 0
 roi = (total_equity - base["baseline_equity"]) / base["baseline_equity"] * 100

--- a/scripts/pick_from_watchlist.py
+++ b/scripts/pick_from_watchlist.py
@@ -19,11 +19,9 @@ RISK_PER_TRADE = 0.10    # 10% of available cash per trade
 def read_cash_and_positions():
     p = Path(__file__).parent.parent / "data" / "portfolio_update.csv"
     df = pd.read_csv(p)
-    # detect cash column name
-    cash_col = "Cash Balance" if "Cash Balance" in df.columns else "Cash"
-    # get latest TOTAL row
+    # get latest TOTAL row and its cash value
     total_row = df[df["Ticker"].str.upper() == "TOTAL"].iloc[-1]
-    cash = float(total_row[cash_col])
+    cash = float(total_row["Cash"])
     # existing positions (ignore TOTAL)
     pos = df[df["Ticker"].str.upper() != "TOTAL"].copy()
     return cash, pos
@@ -83,29 +81,29 @@ def main():
                 "Date": today,
                 "Ticker": t,
                 "Shares": s,
-                "Cost Basis": "",
-                "Stop Loss": "",
-                "Current Price": round(p, 2),
-                "Total Value": round(s * p, 2),
+                "Cost": "",
+                "Stop": "",
+                "Price": round(p, 2),
+                "Value": round(s * p, 2),
                 "PnL": "",
-                "Cash Balance": "",
-                "Total Equity": ""
+                "Cash": "",
+                "Equity": ""
             }
 
         # re-compute TOTAL row for today
         pos = df_pu[df_pu["Ticker"].str.upper() != "TOTAL"]
-        total_val = pos["Total Value"].sum()
+        total_val = pos["Value"].sum()
         df_pu.loc[len(df_pu)] = {
             "Date": today,
             "Ticker": "TOTAL",
             "Shares": "",
-            "Cost Basis": "",
-            "Stop Loss": "",
-            "Current Price": "",
-            "Total Value": "",
+            "Cost": "",
+            "Stop": "",
+            "Price": "",
+            "Value": "",
             "PnL": "",
-            "Cash Balance": round(cash, 2),
-            "Total Equity": round(total_val + cash, 2)
+            "Cash": round(cash, 2),
+            "Equity": round(total_val + cash, 2)
         }
 
         df_pu.to_csv(pu, index=False)

--- a/scripts/set_roi_baseline.py
+++ b/scripts/set_roi_baseline.py
@@ -12,12 +12,12 @@ today = df[df["Date"] == date]
 if today.empty:
     sys.exit(f"No rows for {date} in portfolio_update.csv")
 
-# Prefer Total Equity if present
-if "Total Equity" in today.columns:
-    eq = float(today["Total Equity"].iloc[-1])
-# Otherwise sum Shares * Current Price
+# Prefer Equity if present
+if "Equity" in today.columns:
+    eq = float(today["Equity"].iloc[-1])
+# Otherwise sum Shares * Price
 else:
-    eq = float((today["Shares"] * today["Current Price"]).sum())
+    eq = float((today["Shares"] * today["Price"]).sum())
 
 out = {"date": date, "baseline_equity": eq}
 print(json.dumps(out))


### PR DESCRIPTION
## Summary
- Define standard portfolio_update.csv with canonical column names
- Adjust scripts to read and write unified columns
- Allow portfolio_update.csv to be tracked in git

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689507ecba70832191f4335fb1042e41