### PR TITLE
Initialize total portfolio value early in watchlist script

### DIFF
--- a/scripts/pick_from_watchlist.py
+++ b/scripts/pick_from_watchlist.py
@@ -31,6 +31,7 @@ def read_cash_and_positions():
 # ─── 4) Main logic ─────────────────────────────────────────────────────────────
 def main():
     cash, positions = read_cash_and_positions()
+    total_val = positions["Total Value"].sum()
     risk_capital = cash * RISK_PER_TRADE
 
     new_trades = []


### PR DESCRIPTION
## Summary
- compute total portfolio value at start of `pick_from_watchlist.py` so final message always has a value

## Testing
- `python scripts/pick_from_watchlist.py` (no eligible trades)

------
https://chatgpt.com/codex/tasks/task_e_68950de1a1888321acc59021698e8b47